### PR TITLE
remove chroma option

### DIFF
--- a/src/main/java/dev/salmon/keystrokes/hud/GuiKey.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/GuiKey.java
@@ -12,8 +12,6 @@ import net.minecraft.client.settings.KeyBinding;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
-import java.awt.*;
-
 public class GuiKey extends Gui {
 
     protected final FontRenderer fr;
@@ -57,8 +55,6 @@ public class GuiKey extends Gui {
     }
 
     protected int getTextColor() {
-        if (KeystrokesConfig.keystrokesElement.chroma)
-            return Color.HSBtoRGB((float) (System.currentTimeMillis() % 3000L) / 3000.0F, 0.8F, 1.0F);
         int thisColor = (this.isPressed ? KeystrokesConfig.keystrokesElement.textPressed : KeystrokesConfig.keystrokesElement.textUnpressed).getRGB();
         if (this.percentFaded < 1.0F) {
             int lastColor = (this.isPressed ? KeystrokesConfig.keystrokesElement.textUnpressed : KeystrokesConfig.keystrokesElement.textPressed).getRGB();

--- a/src/main/java/dev/salmon/keystrokes/hud/KeystrokesElement.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/KeystrokesElement.java
@@ -51,11 +51,6 @@ public class KeystrokesElement extends Hud {
     public int fadingTime = 100;
 
     @Switch(
-            name = "Chroma"
-    )
-    public boolean chroma = false;
-
-    @Switch(
             name = "Shadow"
     )
     public boolean shadow = false;


### PR DESCRIPTION
## Description
Removes the chroma option in the config as color selector has chroma support.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
Use chroma in color selector.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Remove chroma option in favor of OneConfig color selector chroma
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A