### PR TITLE
fix not detecting mouse input with <50ms duration

### DIFF
--- a/src/main/java/dev/salmon/keystrokes/Keystrokes.java
+++ b/src/main/java/dev/salmon/keystrokes/Keystrokes.java
@@ -1,11 +1,17 @@
 package dev.salmon.keystrokes;
 
+import cc.polyfrost.oneconfig.events.EventManager;
+import cc.polyfrost.oneconfig.events.event.KeyInputEvent;
+import cc.polyfrost.oneconfig.events.event.MouseInputEvent;
+import cc.polyfrost.oneconfig.libs.eventbus.Subscribe;
 import cc.polyfrost.oneconfig.utils.commands.CommandManager;
 import dev.salmon.keystrokes.command.KeystrokesCommand;
 import dev.salmon.keystrokes.config.KeystrokesConfig;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 
 @Mod(modid = Keystrokes.ID, name = Keystrokes.NAME, version = Keystrokes.VER)
 public class Keystrokes {
@@ -18,9 +24,23 @@ public class Keystrokes {
 
     @EventHandler
     public void init(FMLInitializationEvent event) {
+        EventManager.INSTANCE.register(this);
         CommandManager.INSTANCE.registerCommand(new KeystrokesCommand());
         config = new KeystrokesConfig();
     }
 
+    @Subscribe
+    public void keyboardInput(KeyInputEvent event) {
+        if (!Keyboard.getEventKeyState()) return;
+        KeystrokesConfig.keystrokesElement.pressed(Keyboard.getEventKey());
+    }
+
+
+    @Subscribe
+    public void mouseInput(MouseInputEvent event) {
+        if (!Mouse.getEventButtonState()) return;
+        KeystrokesConfig.keystrokesElement.pressed(Mouse.getEventButton() - 100);
+
+    }
 }
 

--- a/src/main/java/dev/salmon/keystrokes/hud/GuiKey.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/GuiKey.java
@@ -131,10 +131,8 @@ public class GuiKey extends Gui {
             this.percentFaded = 1.0F;
     }
 
-    private boolean isKeyDown(int code) {
-        if (code < 0)
-            return Mouse.isButtonDown(code + 100);
-        return Keyboard.isKeyDown(code);
+    protected boolean isKeyDown(int code) {
+        return (code < 0) ? Mouse.isButtonDown(code + 100) : Keyboard.isKeyDown(code);
     }
 
     protected int getIntermediateColor(int a, int b, float percent) {

--- a/src/main/java/dev/salmon/keystrokes/hud/GuiKeyMouse.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/GuiKeyMouse.java
@@ -1,0 +1,23 @@
+package dev.salmon.keystrokes.hud;
+
+import net.minecraft.client.settings.KeyBinding;
+
+public class GuiKeyMouse extends GuiKey {
+    private boolean pressed;
+
+    public GuiKeyMouse(float x, float y, float width, float height, KeyBinding keyBinding) {
+        super(x, y, width, height, keyBinding);
+    }
+
+    @Override
+    protected boolean isKeyDown(int code) {
+        boolean down = super.isKeyDown(code) || pressed;
+        if (pressed) pressed = false;
+        return down;
+    }
+
+    public void pressed(int code) {
+        if (code != this.keyBinding.getKeyCode()) return;
+        pressed = true;
+    }
+}

--- a/src/main/java/dev/salmon/keystrokes/hud/KeystrokesElement.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/KeystrokesElement.java
@@ -68,7 +68,7 @@ public class KeystrokesElement extends Hud {
     public int cornerRadius = 2;
 
     transient private final GuiKey[] movementKeys;
-    transient private final GuiKey[] mouseKeys;
+    transient private final GuiKeyMouse[] mouseKeys;
     transient private final GuiKey jumpKey;
 
     public KeystrokesElement() {
@@ -78,8 +78,8 @@ public class KeystrokesElement extends Hud {
         this.movementKeys[1] = new GuiKey(0, 20, 19, 19, gs.keyBindLeft);
         this.movementKeys[2] = new GuiKey(20, 20, 19, 19, gs.keyBindBack);
         this.movementKeys[3] = new GuiKey(40, 20, 19, 19, gs.keyBindRight);
-        (this.mouseKeys = new GuiKey[2])[0] = new GuiKey(0, 40, 29, 19, gs.keyBindAttack); // left click
-        this.mouseKeys[1] = new GuiKey(30, 40, 29, 19, gs.keyBindUseItem); // right click
+        (this.mouseKeys = new GuiKeyMouse[2])[0] = new GuiKeyMouse(0, 40, 29, 19, gs.keyBindAttack); // left click
+        this.mouseKeys[1] = new GuiKeyMouse(30, 40, 29, 19, gs.keyBindUseItem); // right click
         this.jumpKey = new GuiKeySpace(0, 60, 59, 11, gs.keyBindJump); // space
     }
 
@@ -125,5 +125,11 @@ public class KeystrokesElement extends Hud {
         if (jumpKeystrokes)
             height += 12;
         return (height * scale);
+    }
+
+    public void pressed(int keycode) {
+        for (GuiKeyMouse mouseKey : mouseKeys) {
+            mouseKey.pressed(keycode);
+        }
     }
 }


### PR DESCRIPTION
## Description
Fixes not detecting mouse input with <50ms duration

## Related Issue(s)
Not detecting mouse input with <50ms duration

## How to test
Quickly tap your mouse would show difference in keystrokes.

## Release Notes
```
Fixes a bug not detecting mouse input with <50ms duration
```

## Documentation
No