### PR TITLE
Implement CPS Counter

### DIFF
--- a/src/main/java/dev/salmon/keystrokes/hud/GuiKey.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/GuiKey.java
@@ -47,6 +47,10 @@ public class GuiKey extends Gui {
         x += (this.width - this.fr.getStringWidth(getKeyName()) + 1) / 2;
         y += (this.height - this.fr.FONT_HEIGHT + 2) / 2;
 
+        if (KeystrokesConfig.keystrokesElement.mouseCPS && this instanceof GuiKeyMouse) {
+            y -= 2;
+        }
+
         GlStateManager.enableBlend();
         this.fr.drawString(getKeyName(), x, y, getTextColor(), KeystrokesConfig.keystrokesElement.shadow);
         GlStateManager.disableBlend();

--- a/src/main/java/dev/salmon/keystrokes/hud/GuiKeyMouse.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/GuiKeyMouse.java
@@ -1,12 +1,35 @@
 package dev.salmon.keystrokes.hud;
 
+import cc.polyfrost.oneconfig.libs.universal.UGraphics;
+import dev.salmon.keystrokes.config.KeystrokesConfig;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.settings.KeyBinding;
+
+import java.util.LinkedList;
+import java.util.Queue;
 
 public class GuiKeyMouse extends GuiKey {
     private boolean pressed;
+    private final Queue<Long> clicks = new LinkedList<>();
 
     public GuiKeyMouse(float x, float y, float width, float height, KeyBinding keyBinding) {
         super(x, y, width, height, keyBinding);
+    }
+
+    public void drawCps(float x, float y, float scale) {
+        String cpsText = getCps() + " CPS";
+        x += this.relX + (this.width / 2 - (float) this.fr.getStringWidth(cpsText) / 4);
+        y += this.relY + (this.height - this.fr.FONT_HEIGHT * scale) - 2;
+
+        UGraphics.GL.pushMatrix();
+        UGraphics.GL.translate(-x * (scale - 1.0F), -y * (scale - 1.0F), 0.0F);
+        UGraphics.GL.scale(scale, scale, 1.0F);
+
+        GlStateManager.enableBlend();
+        this.fr.drawString(cpsText, x, y, getTextColor(), KeystrokesConfig.keystrokesElement.shadow);
+        GlStateManager.disableBlend();
+
+        UGraphics.GL.popMatrix();
     }
 
     @Override
@@ -18,6 +41,17 @@ public class GuiKeyMouse extends GuiKey {
 
     public void pressed(int code) {
         if (code != this.keyBinding.getKeyCode()) return;
+        clicks.add(System.currentTimeMillis() + 1000L);
         pressed = true;
+    }
+
+    private int getCps() {
+        long time = System.currentTimeMillis();
+
+        while (!clicks.isEmpty() && clicks.peek() < time) {
+            clicks.remove();
+        }
+
+        return clicks.size();
     }
 }

--- a/src/main/java/dev/salmon/keystrokes/hud/KeystrokesElement.java
+++ b/src/main/java/dev/salmon/keystrokes/hud/KeystrokesElement.java
@@ -17,6 +17,10 @@ public class KeystrokesElement extends Hud {
     )
     public boolean mouseKeystrokes = true;
     @Switch(
+            name = "Enable Mouse CPS"
+    )
+    public boolean mouseCPS = false;
+    @Switch(
             name = "Jump (Space) Keystrokes"
     )
     public boolean jumpKeystrokes = false;
@@ -97,6 +101,7 @@ public class KeystrokesElement extends Hud {
                 for (GuiKey key : this.mouseKeys) {
                     key.updateKeyState();
                     key.drawKey(x, y, scale);
+                    if (mouseCPS) key.drawCps(x, y, 0.5F);
                 }
             }
             if (jumpKeystrokes) {


### PR DESCRIPTION
## Description
Adds a basic CPS Counter to both LMB and RMB

## Related Issue(s)
Addresses #3 

## How to test
Load the mod into Forge and enable the "Enable Mouse CPS" Option in OneConfig

## Release Notes
```release-note
Implements a CPS Counter
```

## Documentation
No documentation is required.